### PR TITLE
fix: switch to connection status check for postgres adapter

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
+++ b/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb
@@ -306,7 +306,8 @@ module ActiveRecord
       # Is this connection alive and ready for queries?
       def active?
         @lock.synchronize do
-          @connection.query ";"
+          return false unless @raw_connection
+          return false unless @raw_connection.status == 0 # CONNECTION_OK
         end
         true
       rescue PG::Error


### PR DESCRIPTION
### Motivation / Background

This Pull Request has been created because currently whenever a connection is checked out from the pool, it causes a `SELECT 1` or `;` query to be ran against the postgres database in the `active?` check. This causes a round-trip to the database to execute the query (incurring latency). If you have multiple check-in and out during a single request, this can really add up.

### Detail

This Pull Request changes the `active?` check with a check of the underlying connection's object's `status` in `libpq`.

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [ ] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
